### PR TITLE
MachineLearning lazy import of modules

### DIFF
--- a/MachineLearning_Engine/Compute/Audio/PlayAudio.cs
+++ b/MachineLearning_Engine/Compute/Audio/PlayAudio.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.MachineLearning.Audio
         public static void PlayAudio(Tensor audioTensor, int rate = 22050, bool run = false)
         {
             if (run)
-                BH.Engine.MachineLearning.Base.Compute.Invoke("PlayAudio.play_numpy_audio", audioTensor, rate);
+                BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "PlayAudio.play_numpy_audio", audioTensor, rate);
             return;
         }
 

--- a/MachineLearning_Engine/Compute/Audio/RecogniseSpeech.cs
+++ b/MachineLearning_Engine/Compute/Audio/RecogniseSpeech.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.MachineLearning.Audio
 
         public static Tensor RecogniseSpeech(string wavFile = "", bool run = false)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("RecogniseSpeech.infer", wavFile, run));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "RecogniseSpeech.infer", wavFile, run));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Audio/SynthesiseSpeech.cs
+++ b/MachineLearning_Engine/Compute/Audio/SynthesiseSpeech.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.MachineLearning.Audio
 
         public static Tensor SynthesiseSpeech(string text, bool gpu = false)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("SynthesiseSpeech.infer", text, gpu));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "SynthesiseSpeech.infer", text, gpu));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Charts/Diurnal.cs
+++ b/MachineLearning_Engine/Compute/Charts/Diurnal.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.MachineLearning.Charts
             if (!run)
                 return null;
 
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("Diurnal.diurnal", annualValues, savePath, grouping, months, title, unit, color, toneColor, transparency).ToString();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "Diurnal.diurnal", annualValues, savePath, grouping, months, title, unit, color, toneColor, transparency).ToString();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Charts/Frequency.cs
+++ b/MachineLearning_Engine/Compute/Charts/Frequency.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.MachineLearning.Charts
             if (!run)
                 return null;
 
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("Frequency.frequency", values, savePath, title, unit, vRange, bins, color, toneColor, transparency).ToString();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "Frequency.frequency", values, savePath, title, unit, vRange, bins, color, toneColor, transparency).ToString();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Charts/Heatmap.cs
+++ b/MachineLearning_Engine/Compute/Charts/Heatmap.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.MachineLearning.Charts
             if (!run)
                 return null;
 
-            return BH.Engine.MachineLearning.Base.Compute.Invoke(
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, 
                 "Heatmap.heatmap", 
                 annualValues, 
                 savePath, 

--- a/MachineLearning_Engine/Compute/Charts/PlotImage.cs
+++ b/MachineLearning_Engine/Compute/Charts/PlotImage.cs
@@ -33,14 +33,14 @@ namespace BH.Engine.MachineLearning.Charts
 
         public static object PlotImage(Image image, int height, int width, bool grayscale = false)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("PlotImage.plot_pil_image", image, height, width, grayscale);
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "PlotImage.plot_pil_image", image, height, width, grayscale);
         }
 
         /*************************************/
 
         public static object PlotImage(Tensor tensor, int height, int width, bool grayscale = false)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("PlotImage.plot_tensor_image", tensor, height, width, grayscale);
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "PlotImage.plot_tensor_image", tensor, height, width, grayscale);
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Charts/UTCI.cs
+++ b/MachineLearning_Engine/Compute/Charts/UTCI.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.MachineLearning.Charts
             if (!run)
                 return null;
 
-            return BH.Engine.MachineLearning.Base.Compute.Invoke(
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, 
                 "UTCI.utci", 
                 annualValues, 
                 savePath, 

--- a/MachineLearning_Engine/Compute/Invoke.cs
+++ b/MachineLearning_Engine/Compute/Invoke.cs
@@ -22,6 +22,7 @@
 
 using Python.Runtime;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Engine.MachineLearning.Base
 {
@@ -31,9 +32,9 @@ namespace BH.Engine.MachineLearning.Base
         /**** Public Methods              ****/
         /*************************************/
 
-        public static PyObject Invoke(string method, params object[] args)
+        public static PyObject Invoke(string nameSpace, string method, params object[] args)
         {
-            PyObject mlComputeModule = Query.Import("MachineLearning_Engine.Compute");
+            PyObject mlComputeModule = Query.Import("MachineLearning_Engine.Compute." + nameSpace.Split('.').Last());
 
             PyObject[] pyargs = new PyObject[args.Length];
             for (int i = 0; i < args.Length; i++)
@@ -44,9 +45,9 @@ namespace BH.Engine.MachineLearning.Base
 
         /*************************************/
 
-        public static PyObject Invoke(string method, Dictionary<string, object> kwargs)
+        public static PyObject Invoke(string nameSpace, string method, Dictionary<string, object> kwargs)
         {
-            PyObject mlComputeModule = Query.Import("MachineLearning_Engine.Compute");
+            PyObject mlComputeModule = Query.Import("MachineLearning_Engine.Compute." + nameSpace.Split('.').Last());
             return BH.Engine.Python.Compute.Invoke(mlComputeModule, method, null, kwargs);
         }
 

--- a/MachineLearning_Engine/Compute/Preprocessing/MinMaxScaler.cs
+++ b/MachineLearning_Engine/Compute/Preprocessing/MinMaxScaler.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("scaler", "The estimated scaler for the min-max scale transformation.")]
         public static MinMaxScaler MinMaxScaler(Tensor x)
         {
-            PyObject scaler = BH.Engine.MachineLearning.Base.Compute.Invoke("MinMaxScaler.fit", x);
+            PyObject scaler = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "MinMaxScaler.fit", x);
             return new MinMaxScaler(scaler);
         }
 
@@ -50,7 +50,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("rescaledX", "The rescaled data with a range between o and 1.")]
         public static Tensor Infer(MinMaxScaler scaler, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("MinMaxScaler.infer", scaler, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "MinMaxScaler.infer", scaler, x));
         }
 
         /*************************************/
@@ -60,7 +60,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("inversedX", "The inverse transformed data using the min-max scaler.")]
         public static Tensor InferInverse(MinMaxScaler scaler, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("MinMaxScaler.infer_inverse", scaler, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "MinMaxScaler.infer_inverse", scaler, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Preprocessing/PolynomialFeatures.cs
+++ b/MachineLearning_Engine/Compute/Preprocessing/PolynomialFeatures.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("transformer", "The transformer for the polynomial and interaction features of the data.")]
         public static PolynomialFeatures PolynomialFeatures(int degree = 2, bool interaction_only = false)
         {
-            PyObject transformer = BH.Engine.MachineLearning.Base.Compute.Invoke("PolynomialFeatures.fit", degree, interaction_only);
+            PyObject transformer = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "PolynomialFeatures.fit", degree, interaction_only);
             return new PolynomialFeatures(transformer);
         }
 
@@ -51,7 +51,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("transformedX", "The polynomial and interaction features of the data.")]
         public static Tensor Infer(PolynomialFeatures transformer, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("PolynomialFeatures.infer", transformer, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "PolynomialFeatures.infer", transformer, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Preprocessing/StandardScaler.cs
+++ b/MachineLearning_Engine/Compute/Preprocessing/StandardScaler.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("scaler", "The estimated scaler for the standard scale transformation.")]
         public static StandardScaler StandardScaler(Tensor x)
         {
-            PyObject scaler = BH.Engine.MachineLearning.Base.Compute.Invoke("StandardScaler.fit", x);
+            PyObject scaler = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "StandardScaler.fit", x);
             return new StandardScaler(scaler);
         }
 
@@ -50,7 +50,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("rescaledX", "The rescaled data after the given standard scale transformation.")]
         public static Tensor Infer(StandardScaler scaler, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("StandardScaler.infer", scaler, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "StandardScaler.infer", scaler, x));
         }
 
         /*************************************/
@@ -60,7 +60,7 @@ namespace BH.Engine.MachineLearning.Preprocessing
         [Output("inversedX", "The inverse transformed data using the standard scaler.")]
         public static Tensor InferInverse(StandardScaler scaler, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("StandardScaler.infer_inverse", scaler, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "StandardScaler.infer_inverse", scaler, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Structured/LinearRegression.cs
+++ b/MachineLearning_Engine/Compute/Structured/LinearRegression.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.MachineLearning.Structured
         [Output("model", "The ordinary least squares linear regression with the given data.")]
         public static LinearRegression LinearRegression(Tensor x, Tensor y)
         {
-            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke("LinearRegression.fit", x, y);
+            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LinearRegression.fit", x, y);
             return new LinearRegression(model);
         }
 
@@ -56,7 +56,7 @@ namespace BH.Engine.MachineLearning.Structured
         [Output("y", "The projected output for the given data using the linear model.")]
         public static Tensor Infer(LinearRegression model, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("LinearRegression.infer", model, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LinearRegression.infer", model, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Structured/LogisticRegression.cs
+++ b/MachineLearning_Engine/Compute/Structured/LogisticRegression.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.MachineLearning.Structured
         [Output("model", "The ordinary least squares linear regression with the given data.")]
         public static LogisticRegression LogisticRegression(Tensor x, Tensor y)
         {
-            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke("LogisticRegression.fit", x, y);
+            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LogisticRegression.fit", x, y);
             return new LogisticRegression(model);
         }
 
@@ -56,7 +56,7 @@ namespace BH.Engine.MachineLearning.Structured
         [Output("y", "The projected output for the given data using the linear model.")]
         public static Tensor Infer(LogisticRegression model, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("LogisticRegression.infer", model, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LogisticRegression.infer", model, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Structured/SupportVectorRegression.cs
+++ b/MachineLearning_Engine/Compute/Structured/SupportVectorRegression.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.MachineLearning.Structured
 
         public static SupportVectorRegression SupportVectorRegression(Tensor x, Tensor y, string kernel = "rbf", int degree = 3, double regularisation = 1.0)
         {
-            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke("SupportVectorRegression.fit", x, y, kernel, degree, regularisation);
+            PyObject model = BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "SupportVectorRegression.fit", x, y, kernel, degree, regularisation);
             return new SupportVectorRegression(model);
         }
 
@@ -48,7 +48,7 @@ namespace BH.Engine.MachineLearning.Structured
 
         public static Tensor Infer(SupportVectorRegression model, Tensor x)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("SupportVectorRegression.infer", model, x));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "SupportVectorRegression.infer", model, x));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Text/Answer.cs
+++ b/MachineLearning_Engine/Compute/Text/Answer.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.MachineLearning.Text
 
         public static string Answer(string question, string context = "")
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("Answer.infer", question, context).As<string>();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "Answer.infer", question, context).As<string>();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Text/SentimentAnalysis.cs
+++ b/MachineLearning_Engine/Compute/Text/SentimentAnalysis.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.MachineLearning.Text
 
         public static double SentimentAnalysis(string text)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("SentimentAnalysis.infer", text).As<double>();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "SentimentAnalysis.infer", text).As<double>();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Text/Summarise.cs
+++ b/MachineLearning_Engine/Compute/Text/Summarise.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.MachineLearning.Text
 
         public static string Summarise(string text)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("Summarise.infer", text).As<string>();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "Summarise.infer", text).As<string>();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Vision/DetectObjects.cs
+++ b/MachineLearning_Engine/Compute/Vision/DetectObjects.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.MachineLearning.Vision
 
         public static object DetectObjects(string imagePath, bool gpu = false, double scoreThreshold = 0.9)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("DetectObjects.infer", imagePath, gpu, scoreThreshold);
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "DetectObjects.infer", imagePath, gpu, scoreThreshold);
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Vision/DrawDetection.cs
+++ b/MachineLearning_Engine/Compute/Vision/DrawDetection.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.MachineLearning.Vision
 
         public static Tensor DrawDetection(string imagePath, PyObject detection, double minAccuracy=0.8)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("DrawDetection.draw_detection", imagePath, detection, minAccuracy));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "DrawDetection.draw_detection", imagePath, detection, minAccuracy));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Vision/FindContours.cs
+++ b/MachineLearning_Engine/Compute/Vision/FindContours.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.MachineLearning.Vision
         {
             List<Polyline> polylines = new List<Polyline>();
             // returns a list of points as numpy arrays
-            List<object> contours = (BH.Engine.MachineLearning.Base.Compute.Invoke("FindContours.infer", image, level).IFromPython()) as List<object>;
+            List<object> contours = (BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "FindContours.infer", image, level).IFromPython()) as List<object>;
             foreach (List<List<double>> polyline in contours)
             {
                 Polyline bhomPolyline = new Polyline();

--- a/MachineLearning_Engine/Compute/Vision/RecogniseObject.cs
+++ b/MachineLearning_Engine/Compute/Vision/RecogniseObject.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.MachineLearning.Vision
         [Output("Object", "The probabilities (score) for each class. Use the Query.ImageClasses() method to match ")]
         public static string RecogniseObject(string imagePath, bool gpu = false)
         {
-            return BH.Engine.MachineLearning.Base.Compute.Invoke("RecogniseObject.infer", imagePath, gpu).As<string>();
+            return BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "RecogniseObject.infer", imagePath, gpu).As<string>();
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Vision/SemanticSegmentation.cs
+++ b/MachineLearning_Engine/Compute/Vision/SemanticSegmentation.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.MachineLearning.Vision
 
         public static Tensor SegmentImage(string imagePath, bool gpu = false)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("SemanticSegmentation.infer", imagePath, gpu));
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "SemanticSegmentation.infer", imagePath, gpu));
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/__init__.py
+++ b/MachineLearning_Engine/Compute/__init__.py
@@ -19,31 +19,3 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 #
-
-from .Audio import PlayAudio
-from .Audio import SynthesiseSpeech
-from .Audio import RecogniseSpeech
-
-from .Charts import Diurnal
-from .Charts import UTCI
-from .Charts import Frequency
-from .Charts import Heatmap
-from .Charts import PlotImage
-
-from .Preprocessing import MinMaxScaler
-from .Preprocessing import PolynomialFeatures
-from .Preprocessing import StandardScaler
-
-from .Structured import LinearRegression
-from .Structured import SupportVectorRegression
-from .Structured import LogisticRegression
-
-from .Text import Answer
-from .Text import SentimentAnalysis
-from .Text import Summarise
-
-from .Vision import DetectObjects
-from .Vision import DrawDetection
-from .Vision import FindContours
-from .Vision import RecogniseObject
-from .Vision import SemanticSegmentation

--- a/MachineLearning_Engine/Query/Error.cs
+++ b/MachineLearning_Engine/Query/Error.cs
@@ -44,14 +44,14 @@ namespace BH.Engine.MachineLearning
         [Output("r2", "The coefficient of determination R^2 of the prediction.")]
         public static Tensor Error(LinearRegression model, Tensor x, Tensor y)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("LinearRegression.error", model, x, y)); ;
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LinearRegression.error", model, x, y)); ;
         }
 
         /*************************************/
 
         public static Tensor Error(LogisticRegression model, Tensor x, Tensor y)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke("LogisticRegression.error", model, x, y)); ;
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LogisticRegression.error", model, x, y)); ;
         }
 
         /*************************************/

--- a/MachineLearning_Toolkit.sln
+++ b/MachineLearning_Toolkit.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{82F38474-BA80-4CAA-991C-B787A8D9186E}"
 	ProjectSection(SolutionItems) = preProject
 		requirements.txt = requirements.txt
+		setup.py = setup.py
 	EndProjectSection
 EndProject
 Global

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     "MachineLearning_Engine.Compute",
     "MachineLearning_Engine.Compute.Audio",
     "MachineLearning_Engine.Compute.Charts",
-    "MachineLearning_Engine.Compute.Geometry",
     "MachineLearning_Engine.Compute.Preprocessing",
     "MachineLearning_Engine.Compute.Structured",
     "MachineLearning_Engine.Compute.Text",

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,19 @@
 from distutils.core import setup
 
 setup(
-    name='MachineLearning_Engine',
+    name='MachineLearning_Toolkit',
     description='A Machine Learning Framework for the Buildings and Habitats object Model',
     author='Eduardo Pignatelli',
     author_email='info@bhom.xyz',
     license='LGPLv3',
-    packages=["MachineLearning_Engine", "MachineLearning_Engine.Compute"],
-    version="3.1.0.0",
+    packages=["MachineLearning_Engine",
+    "MachineLearning_Engine.Compute",
+    "MachineLearning_Engine.Compute.Audio",
+    "MachineLearning_Engine.Compute.Charts",
+    "MachineLearning_Engine.Compute.Geometry",
+    "MachineLearning_Engine.Compute.Preprocessing",
+    "MachineLearning_Engine.Compute.Structured",
+    "MachineLearning_Engine.Compute.Text",
+    "MachineLearning_Engine.Compute.Vision"],
+    version="4.0.0.0",
     )


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Python_Toolkit/pull/49
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #51 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/MachineLearning_Toolkit/Examples/Structured.Examples.gh?csf=1&web=1&e=Uo2IZ4

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Adjust package information to break into smaller modules
 - Change invoke to obtain namespace
 - Change import to load necessary module only base on namespace
 - Necessary adjustment for import check in Python_Toolkit https://github.com/BHoM/Python_Toolkit/pull/49

### Additional comments
<!-- As required -->
 - This lazy import will remove the road blocker of all machine learning methods working in Rhino 6.
 - However, this did not solve the pandas import issue in Rhino 6 #31 . Currently only Climate charts functionality is using pandas so for those who need to use those methods, they still need to go to Rhino 5.