### PR TITLE
Made description valid for API 

### DIFF
--- a/MachineLearning_Engine/Compute/Datasets/LoadCsv.cs
+++ b/MachineLearning_Engine/Compute/Datasets/LoadCsv.cs
@@ -39,8 +39,8 @@ namespace BH.Engine.MachineLearning.Datasets
         /*************************************/
 
         [Description("Reads a csv file and loads it into a Tensor primitive.")]
-        [Input("path", "The path to the csv file. If using a relative path, the root will be C:\\ProgramData\\BHoM")]
-        [Input("separator", "The separator character of the csv, e,g, a tsv. Use \t for tabs.")]
+        [Input("path", "The path to the csv file. If using a relative path, the root will be C:/ProgramData/BHoM")]
+        [Input("separator", "The separator character of the csv, e,g, a tsv. Use \\t for tabs.")]
         [Input("hasHeaders", "True if the first line of the csv is a headers line, false otherwise.")]
         [MultiOutput(0, "headers", "A list of headers as string if headers are present in the csv. An empty list otherswise.")]
         [MultiOutput(1, "tensor", "A 2D tensor with dimensions (numberOfRow, numberOfColumns)")]


### PR DESCRIPTION
 
### Issues addressed by this PR

Closes #63 

Makes description valid for API by removing the use of \
