### PR TITLE
Fix Query.Error and ToList

### DIFF
--- a/MachineLearning_Engine/Compute/Structured/Coefficients.cs
+++ b/MachineLearning_Engine/Compute/Structured/Coefficients.cs
@@ -29,7 +29,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace BH.Engine.MachineLearning
+namespace BH.Engine.MachineLearning.Structured
 {
     public static partial class Query
     {
@@ -37,21 +37,15 @@ namespace BH.Engine.MachineLearning
         /**** Public Fields              ****/
         /*************************************/
 
-        [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
-        [Input("model", "The linear regressor model used for inference.")]
-        [Input("x", "Training data as a list of 2-elements list.")]
-        [Input("y", "Target values as a list of 2-elements list.")]
-        [Output("r2", "The coefficient of determination R^2 of the prediction.")]
-        public static Tensor Error(LinearRegression model, Tensor x, Tensor y)
+        [Description("Expose the attributes for the given regression model.")]
+        [Input("model", "The regression model used for inference.")]
+        [MultiOutput(0, "coefficients", "Estimated coefficients for the regression model. This is a 1D array of double.")]
+        [MultiOutput(1, "intercept", "The independent term in the model.")]
+        public static Output<Tensor, Tensor> Coefficients(LinearRegression model)
         {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LinearRegression.error", model, x, y)); ;
-        }
-
-        /*************************************/
-
-        public static Tensor Error(LogisticRegression model, Tensor x, Tensor y)
-        {
-            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, "LogisticRegression.error", model, x, y)); ;
+            Tensor coefficients = new Tensor(model.SkLearnModel.GetAttr("coef_"));
+            Tensor intercept = new Tensor(model.SkLearnModel.GetAttr("intercept_")); 
+            return new Output<Tensor, Tensor> { Item1 = coefficients, Item2 = intercept };
         }
 
         /*************************************/

--- a/MachineLearning_Engine/Compute/Structured/Coefficients.cs
+++ b/MachineLearning_Engine/Compute/Structured/Coefficients.cs
@@ -37,11 +37,12 @@ namespace BH.Engine.MachineLearning.Structured
         /**** Public Fields              ****/
         /*************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Query.Coefficients(BH.oM.MachineLearning.LinearRegression)")]
         [Description("Expose the attributes for the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [MultiOutput(0, "coefficients", "Estimated coefficients for the regression model. This is a 1D array of double.")]
         [MultiOutput(1, "intercept", "The independent term in the model.")]
-        public static Output<Tensor, Tensor> Coefficients(LinearRegression model)
+        public static Output<Tensor, Tensor> Coefficients(IRegressionModel model)
         {
             Tensor coefficients = new Tensor(model.SkLearnModel.GetAttr("coef_"));
             Tensor intercept = new Tensor(model.SkLearnModel.GetAttr("intercept_")); 

--- a/MachineLearning_Engine/Compute/Structured/Coefficients.cs
+++ b/MachineLearning_Engine/Compute/Structured/Coefficients.cs
@@ -31,7 +31,7 @@ using System.ComponentModel;
 
 namespace BH.Engine.MachineLearning.Structured
 {
-    public static partial class Query
+    public static partial class Compute
     {
         /*************************************/
         /**** Public Fields              ****/

--- a/MachineLearning_Engine/Compute/Structured/LinearRegression.py
+++ b/MachineLearning_Engine/Compute/Structured/LinearRegression.py
@@ -47,7 +47,7 @@ def infer(model: LinearRegression, x: np.ndarray):
 		x = x.reshape(-1, 1)
 	return model.predict(x)
 
-def error(model: LinearRegression, x: np.ndarray, y: np.ndarray):
+def score(model: LinearRegression, x: np.ndarray, y: np.ndarray):
 	# make sure the input is at least bidimensinal
 	if x.ndim == 1:
 		x = x.reshape(-1, 1)

--- a/MachineLearning_Engine/Compute/Structured/LogisticRegression.py
+++ b/MachineLearning_Engine/Compute/Structured/LogisticRegression.py
@@ -47,7 +47,7 @@ def infer(model: LogisticRegression, x: np.ndarray):
 		x = x.reshape(-1, 1)
 	return model.predict(x)
 
-def error(model: LogisticRegression, x: np.ndarray, y: np.ndarray):
+def score(model: LogisticRegression, x: np.ndarray, y: np.ndarray):
 	# make sure the input is at least bidimensinal
 	if x.ndim == 1:
 		x = x.reshape(-1, 1)

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -29,7 +29,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace BH.Engine.MachineLearning
+namespace BH.Engine.MachineLearning.Structured
 {
     public static partial class Query
     {
@@ -37,18 +37,15 @@ namespace BH.Engine.MachineLearning
         /**** Public Fields              ****/
         /*************************************/
 
-        [Description("Expose the attributes for the given regression model.")]
-        [Input("model", "The linear regressor model used for inference.")]
-        [MultiOutput(0, "coefficients", "Estimated coefficients for the linear regression model. This is a 1D array of double.")]
-        [MultiOutput(1, "intercept", "The independent term in the linear model.")]
-        public static Output<Tensor, Tensor> Coefficients(LinearRegression model)
+        [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
+        [Input("model", "The regression model used for inference.")]
+        [Input("x", "Training data as a list of 2-elements list.")]
+        [Input("y", "Target values as a list of 2-elements list.")]
+        [Output("r2", "The coefficient of determination R^2 of the prediction.")]
+        public static Tensor Score(LinearRegression model, Tensor x, Tensor y)
         {
-            Tensor coefficients = new Tensor(model.SkLearnModel.GetAttr("coef_"));
-            Tensor intercept = new Tensor(model.SkLearnModel.GetAttr("intercept_")); 
-            return new Output<Tensor, Tensor> { Item1 = coefficients, Item2 = intercept };
+            return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, model.GetType().Name.ToString() + ".score", model, x, y));
         }
-
-        /*************************************/
     }
 }
 

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -31,7 +31,7 @@ using System.ComponentModel;
 
 namespace BH.Engine.MachineLearning.Structured
 {
-    public static partial class Query
+    public static partial class Compute
     {
         /*************************************/
         /**** Public Fields              ****/
@@ -44,7 +44,7 @@ namespace BH.Engine.MachineLearning.Structured
         [Input("x", "Training data as a list of 2-elements list.")]
         [Input("y", "Target values as a list of 2-elements list.")]
         [Output("r2", "The coefficient of determination R^2 of the prediction.")]
-        public static Tensor Score(LinearRegression model, Tensor x, Tensor y)
+        public static Tensor Score(IRegressionModel model, Tensor x, Tensor y)
         {
             return new Tensor(BH.Engine.MachineLearning.Base.Compute.Invoke(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Namespace, model.GetType().Name.ToString() + ".score", model, x, y));
         }

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -37,8 +37,8 @@ namespace BH.Engine.MachineLearning.Structured
         /**** Public Fields              ****/
         /*************************************/
 
-        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearningTensor)")]
-        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearningTensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
         [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [Input("x", "Training data as a list of 2-elements list.")]

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -38,7 +38,6 @@ namespace BH.Engine.MachineLearning.Structured
         /*************************************/
 
         [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
-        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
         [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [Input("x", "Training data as a list of 2-elements list.")]

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -37,6 +37,8 @@ namespace BH.Engine.MachineLearning.Structured
         /**** Public Fields              ****/
         /*************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearningTensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearningTensor)")]
         [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [Input("x", "Training data as a list of 2-elements list.")]

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -38,6 +38,7 @@ namespace BH.Engine.MachineLearning.Structured
         /*************************************/
 
         [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
         [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [Input("x", "Training data as a list of 2-elements list.")]

--- a/MachineLearning_Engine/Compute/Structured/Score.cs
+++ b/MachineLearning_Engine/Compute/Structured/Score.cs
@@ -37,8 +37,8 @@ namespace BH.Engine.MachineLearning.Structured
         /**** Public Fields              ****/
         /*************************************/
 
-        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
-        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Query.Error(BH.oM.MachineLearning.LinearRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
+        [PreviousVersion("4.1", "BH.Engine.MachineLearning.Query.Error(BH.oM.MachineLearning.LogisticRegression, BH.oM.MachineLearning.Tensor, BH.oM.MachineLearning.Tensor)")]
         [Description("Finds the The coefficient of determination R^2 of the given regression model.")]
         [Input("model", "The regression model used for inference.")]
         [Input("x", "Training data as a list of 2-elements list.")]

--- a/MachineLearning_Engine/Compute/Structured/SupportVectorRegression.py
+++ b/MachineLearning_Engine/Compute/Structured/SupportVectorRegression.py
@@ -48,7 +48,7 @@ def infer(model: SVR, x: np.ndarray):
 	return model.predict(x)
 
 
-def error(model: SVR, x: np.ndarray, y: np.ndarray):
+def score(model: SVR, x: np.ndarray, y: np.ndarray):
 	# make sure the input is at least bidimensinal
 	if x.ndim == 1:
 		x = x.reshape(-1, 1)

--- a/MachineLearning_Engine/Convert/ToList.cs
+++ b/MachineLearning_Engine/Convert/ToList.cs
@@ -45,7 +45,6 @@ namespace BH.Engine.MachineLearning
                 int size = tensor.Size();
 
                 double[] array = new double[size];
-                Engine.Reflection.Compute.RecordNote(array.Length.ToString());
                 Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
 
                 return array.ToList();

--- a/MachineLearning_Engine/Convert/ToList.cs
+++ b/MachineLearning_Engine/Convert/ToList.cs
@@ -39,26 +39,74 @@ namespace BH.Engine.MachineLearning
         [Description("Convert a Tensor to a list of data.")]
         [Input("tensor", "A Tensor to be converted.")]
         [Output("data", "A list of data contained in the Tensor.")]
-        public static List<double> ToList(this Tensor tensor)
+        public static List<object> ToList(this Tensor tensor)
         {
-            // TODO: For the moment we only provide data as double back to C#
+            // TODO: For the moment we only provide data as double or int back to C#
             // It would be good to find a way to return different types
             // The obstacle is that Marshal.Copy does not work on generic types
             if (tensor.NumpyArray.IsIterable())
             {
-                long ptr = tensor.NumpyArray.GetAttr("ctypes").GetAttr("data").As<long>();
-                int size = tensor.Size();
-
-                double[] array = new double[size];
-                Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
-
-                return array.ToList();
+                if (Query.DType(tensor) == typeof(int))
+                    return ToListInt(tensor).Cast<object>().ToList();
+                if (Query.DType(tensor) == typeof(double))
+                    return ToListDouble(tensor).Cast<object>().ToList();
             }
             else
             {
-                List<double> list = new List<double> { System.Convert.ToDouble(tensor.NumpyArray.ToString()) };
-                return list;
+                if (Query.DType(tensor) == typeof(int))
+                    return new List<object> { ToInt(tensor) };
+                if (Query.DType(tensor) == typeof(double))
+                    return new List<object> { ToDouble(tensor) };
             }
+            return null;
+        }
+        /***************************************************/
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        [Description("Convert a Tensor to a list of data.")]
+        [Input("tensor", "A Tensor to be converted.")]
+        [Output("data", "A list of data contained in the Tensor.")]
+        private static List<double> ToListDouble(this Tensor tensor)
+        {
+            long ptr = tensor.NumpyArray.GetAttr("ctypes").GetAttr("data").As<long>();
+            int size = tensor.Size();
+
+            double[] array = new double[size];
+            Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
+
+            return array.ToList();
+        }
+
+        [Description("Convert a Tensor to a list of data.")]
+        [Input("tensor", "A Tensor to be converted.")]
+        [Output("data", "A list of data contained in the Tensor.")]
+        private static List<int> ToListInt(this Tensor tensor)
+        {
+            long ptr = tensor.NumpyArray.GetAttr("ctypes").GetAttr("data").As<long>();
+            int size = tensor.Size();
+
+            int[] array = new int[size];
+            Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
+
+            return array.ToList();
+        }
+
+        [Description("Convert a Tensor to a list of data.")]
+        [Input("tensor", "A Tensor to be converted.")]
+        [Output("data", "A list of data contained in the Tensor.")]
+        private static int ToInt(this Tensor tensor)
+        {
+            return System.Convert.ToInt32(tensor.NumpyArray.ToString());
+        }
+
+        [Description("Convert a Tensor to a list of data.")]
+        [Input("tensor", "A Tensor to be converted.")]
+        [Output("data", "A list of data contained in the Tensor.")]
+        private static double ToDouble(this Tensor tensor)
+        {
+            return System.Convert.ToDouble(tensor.NumpyArray.ToString());
         }
         /***************************************************/
     }

--- a/MachineLearning_Engine/Convert/ToList.cs
+++ b/MachineLearning_Engine/Convert/ToList.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.MachineLearning
         /***************************************************/
 
         [Description("Convert a Tensor to a list of data.")]
-        [Input("x", "A Tensor to be converted.")]
+        [Input("tensor", "A Tensor to be converted.")]
         [Output("data", "A list of data contained in the Tensor.")]
         public static List<double> ToList(this Tensor tensor)
         {

--- a/MachineLearning_Engine/Convert/ToList.cs
+++ b/MachineLearning_Engine/Convert/ToList.cs
@@ -39,15 +39,23 @@ namespace BH.Engine.MachineLearning
             // TODO: For the moment we only provide data as double back to C#
             // It would be good to find a way to return different types
             // The obstacle is that Marshal.Copy does not work on generic types
-            long ptr = tensor.NumpyArray.GetAttr("ctypes").GetAttr("data").As<long>();
-            int size = tensor.Size();
+            if (tensor.NumpyArray.IsIterable())
+            {
+                long ptr = tensor.NumpyArray.GetAttr("ctypes").GetAttr("data").As<long>();
+                int size = tensor.Size();
 
-            double[] array = new double[size];
-            Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
+                double[] array = new double[size];
+                Engine.Reflection.Compute.RecordNote(array.Length.ToString());
+                Marshal.Copy(new IntPtr(ptr), array, 0, array.Length);
 
-            return array.ToList();
+                return array.ToList();
+            }
+            else
+            {
+                List<double> list = new List<double> { System.Convert.ToDouble(tensor.NumpyArray.ToString()) };
+                return list;
+            }
         }
-
         /***************************************************/
     }
 }

--- a/MachineLearning_Engine/Convert/ToList.cs
+++ b/MachineLearning_Engine/Convert/ToList.cs
@@ -21,10 +21,12 @@
  */
 
 using BH.oM.MachineLearning;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace BH.Engine.MachineLearning
 {
@@ -34,6 +36,9 @@ namespace BH.Engine.MachineLearning
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Convert a Tensor to a list of data.")]
+        [Input("x", "A Tensor to be converted.")]
+        [Output("data", "A list of data contained in the Tensor.")]
         public static List<double> ToList(this Tensor tensor)
         {
             // TODO: For the moment we only provide data as double back to C#

--- a/MachineLearning_Engine/MachineLearning_Engine.csproj
+++ b/MachineLearning_Engine/MachineLearning_Engine.csproj
@@ -100,14 +100,14 @@
     <Compile Include="Compute\Invoke.cs" />
     <Compile Include="Convert\FromDType.cs" />
     <Compile Include="Modify\AsType.cs" />
-    <Compile Include="Query\Error.cs" />
+    <Compile Include="Compute\Structured\Score.cs" />
     <Compile Include="Query\DType.cs" />
     <Compile Include="Convert\ToPython.cs" />
     <Compile Include="Create\Tensor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Convert\ToList.cs" />
     <Compile Include="Convert\ToDType.cs" />
-    <Compile Include="Query\Coefficients.cs" />
+    <Compile Include="Compute\Structured\Coefficients.cs" />
     <Compile Include="Query\Import.cs" />
     <Compile Include="Query\GetAttribute.cs" />
     <Compile Include="Query\Shape.cs" />

--- a/MachineLearning_oM/IRegressionModel.cs
+++ b/MachineLearning_oM/IRegressionModel.cs
@@ -20,31 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
-using Python.Runtime;
-
 namespace BH.oM.MachineLearning
 {
-    public class StandardScaler : BHoMObject, ITransformer, IImmutable
-    {
-        /***************************************************/
-        /**** Properties                                ****/
-        /***************************************************/
-
-        public virtual PyObject SkLearnScaler { get; } = null;
-
-
-        /***************************************************/
-        /**** Constructors                              ****/
-        /***************************************************/
-
-        public StandardScaler(PyObject skLearnScaler)
-        {
-            SkLearnScaler = skLearnScaler;
-        }
-
-
-        /***************************************************/
-    }
+    public interface IRegressionModel { }
 }
 

--- a/MachineLearning_oM/IRegressionModel.cs
+++ b/MachineLearning_oM/IRegressionModel.cs
@@ -20,8 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using Python.Runtime;
+
 namespace BH.oM.MachineLearning
 {
-    public interface IRegressionModel { }
+    public interface IRegressionModel
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        PyObject SkLearnModel { get; }
+    }
 }
 

--- a/MachineLearning_oM/IScaler.cs
+++ b/MachineLearning_oM/IScaler.cs
@@ -22,6 +22,8 @@
 
 namespace BH.oM.MachineLearning
 {
-    public interface IScaler { }
+    public interface IScaler 
+    {
+    }
 }
 

--- a/MachineLearning_oM/IScaler.cs
+++ b/MachineLearning_oM/IScaler.cs
@@ -20,31 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
-using Python.Runtime;
-
 namespace BH.oM.MachineLearning
 {
-    public class StandardScaler : BHoMObject, IScaler, IImmutable
-    {
-        /***************************************************/
-        /**** Properties                                ****/
-        /***************************************************/
-
-        public virtual PyObject SkLearnScaler { get; } = null;
-
-
-        /***************************************************/
-        /**** Constructors                              ****/
-        /***************************************************/
-
-        public StandardScaler(PyObject skLearnScaler)
-        {
-            SkLearnScaler = skLearnScaler;
-        }
-
-
-        /***************************************************/
-    }
+    public interface IScaler { }
 }
 

--- a/MachineLearning_oM/ITransformer.cs
+++ b/MachineLearning_oM/ITransformer.cs
@@ -22,6 +22,6 @@
 
 namespace BH.oM.MachineLearning
 {
-    public interface IModel { }
+    public interface ITransformer { }
 }
 

--- a/MachineLearning_oM/ITransformer.cs
+++ b/MachineLearning_oM/ITransformer.cs
@@ -22,6 +22,8 @@
 
 namespace BH.oM.MachineLearning
 {
-    public interface ITransformer { }
+    public interface ITransformer 
+    {
+    }
 }
 

--- a/MachineLearning_oM/LinearRegression.cs
+++ b/MachineLearning_oM/LinearRegression.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class LinearRegression : BHoMObject, IModel, IImmutable
+    public class LinearRegression : BHoMObject, IRegressionModel, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/MachineLearning_oM/LogisticRegression.cs
+++ b/MachineLearning_oM/LogisticRegression.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class LogisticRegression : BHoMObject, IModel, IImmutable
+    public class LogisticRegression : BHoMObject, IRegressionModel, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/MachineLearning_oM/MachineLearning_oM.csproj
+++ b/MachineLearning_oM/MachineLearning_oM.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IScaler.cs" />
     <Compile Include="ITransformer.cs" />
     <Compile Include="LogisticRegression.cs" />
     <Compile Include="SupportVectorRegression.cs" />

--- a/MachineLearning_oM/MachineLearning_oM.csproj
+++ b/MachineLearning_oM/MachineLearning_oM.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ITransformer.cs" />
     <Compile Include="LogisticRegression.cs" />
     <Compile Include="SupportVectorRegression.cs" />
     <Compile Include="Vision\Image.cs" />
@@ -63,7 +64,7 @@
     <Compile Include="StandardScaler.cs" />
     <Compile Include="MinMaxScaler.cs" />
     <Compile Include="LinearRegression.cs" />
-    <Compile Include="IModel.cs" />
+    <Compile Include="IRegressionModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tensor.cs" />
   </ItemGroup>

--- a/MachineLearning_oM/MinMaxScaler.cs
+++ b/MachineLearning_oM/MinMaxScaler.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class MinMaxScaler : BHoMObject, IModel, IImmutable
+    public class MinMaxScaler : BHoMObject, ITransformer, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/MachineLearning_oM/MinMaxScaler.cs
+++ b/MachineLearning_oM/MinMaxScaler.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class MinMaxScaler : BHoMObject, ITransformer, IImmutable
+    public class MinMaxScaler : BHoMObject, IScaler, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/MachineLearning_oM/PolynomialFeatures.cs
+++ b/MachineLearning_oM/PolynomialFeatures.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class PolynomialFeatures : BHoMObject, IModel, IImmutable
+    public class PolynomialFeatures : BHoMObject, ITransformer, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/MachineLearning_oM/SupportVectorRegression.cs
+++ b/MachineLearning_oM/SupportVectorRegression.cs
@@ -25,7 +25,7 @@ using Python.Runtime;
 
 namespace BH.oM.MachineLearning
 {
-    public class SupportVectorRegression : BHoMObject, IModel, IImmutable
+    public class SupportVectorRegression : BHoMObject, IRegressionModel, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #65 
Closes #79 
Closes #81 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[MachineLearning#65-Scores-allModels.zip](https://github.com/BHoM/MachineLearning_Toolkit/files/5823695/MachineLearning.65-Scores.zip)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Move Error and Coefficients methods from Query to Structured.Compute, as they only works for models under Structured. (this fix 65)
 - Rename Error method to Score method, to avoid the negative term. (include versioning)
 - Modify Score method to work with interface oM, to avoid adding method for each model.
 - Modify Coefficients method to work with interface, to avoid adding method for each model.
 - Split oM interface
 - Fix ToList method to work with different types of Tensor (fix 79 and 81)

### Additional comments
<!-- As required -->